### PR TITLE
Fix code scanning alert #26: Incorrect conversion between integer types

### DIFF
--- a/client/version/sliver-version.go
+++ b/client/version/sliver-version.go
@@ -55,8 +55,11 @@ func SemanticVersion() []int {
 		version = version[1:]
 	}
 	for _, part := range strings.Split(version, ".") {
-		number, _ := strconv.Atoi(part)
-		semVer = append(semVer, number)
+		number, err := strconv.ParseInt(part, 10, 32)
+		if err != nil {
+			number = 0 // or handle the error as appropriate
+		}
+		semVer = append(semVer, int(number))
 	}
 	return semVer
 }


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/26](https://github.com/offsoc/sliver/security/code-scanning/26)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
