### PR TITLE
Fix code scanning alert #21: Incorrect conversion between integer types

### DIFF
--- a/client/core/portfwd.go
+++ b/client/core/portfwd.go
@@ -166,7 +166,7 @@ func (p *ChannelProxy) HostPort() (string, uint32) {
 		log.Printf("Failed to parse addr %s", p.RemoteAddr)
 		return "", defaultPort
 	}
-	portNumber, err := strconv.Atoi(rawPort)
+	portNumber, err := strconv.ParseUint(rawPort, 10, 32)
 	if err != nil {
 		log.Printf("Failed to parse number from %s", rawPort)
 		return "", defaultPort


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/21](https://github.com/offsoc/sliver/security/code-scanning/21)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
