### PR TITLE
Fix code scanning alert #2: Disabled TLS certificate check

### DIFF
--- a/implant/sliver/transports/mtls/mtls.go
+++ b/implant/sliver/transports/mtls/mtls.go
@@ -172,7 +172,6 @@ func getTLSConfig() *tls.Config {
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{certPEM},
 		RootCAs:            caCertPool,
-		InsecureSkipVerify: true, // Don't worry I sorta know what I'm doing
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			return cryptography.RootOnlyVerifyCertificate(caCertPEM, rawCerts, verifiedChains)
 		},


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/2](https://github.com/offsoc/sliver/security/code-scanning/2)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
