### PR TITLE
Fix code scanning alert #16: Incorrect conversion between integer types

### DIFF
--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -707,7 +707,7 @@ func getExtArgs(_ *cobra.Command, args []string, _ string, ext *ExtCommand) ([]b
 				return nil, err
 			}
 		case "short":
-			val, err := strconv.Atoi(word)
+			val, err := strconv.ParseUint(word, 10, 16)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/16](https://github.com/offsoc/sliver/security/code-scanning/16)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
