### PR TITLE
Fix code scanning alert #39: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -235,9 +235,11 @@ func wgBeacon(uri *url.URL) *Beacon {
 	// {{if .Config.Debug}}
 	log.Printf("Establishing Beacon -> %s", uri.String())
 	// {{end}}
-	lport, err := strconv.Atoi(uri.Port())
-	if err != nil {
+	parsedPort, err := strconv.ParseUint(uri.Port(), 10, 16)
+	if err != nil || parsedPort > 65535 {
 		lport = 53
+	} else {
+		lport = uint16(parsedPort)
 	}
 
 	var conn net.Conn


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/39](https://github.com/offsoc/sliver/security/code-scanning/39)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
