### PR TITLE
Fix code scanning alert #6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/server/assets/assets-helpers.go
+++ b/server/assets/assets-helpers.go
@@ -98,6 +98,9 @@ func unzipBuf(src []byte, dest string) ([]string, error) {
 		defer rc.Close()
 
 		fPath := filepath.Join(dest, file.Name)
+		if !strings.HasPrefix(filepath.Clean(fPath), filepath.Clean(dest) + string(os.PathSeparator)) {
+			return filenames, fmt.Errorf("invalid file path: %s", fPath)
+		}
 		filenames = append(filenames, fPath)
 
 		if file.FileInfo().IsDir() {


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/6](https://github.com/offsoc/sliver/security/code-scanning/6)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
