### PR TITLE
Fix code scanning alert #40: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -232,8 +232,8 @@ func mtlsConnect(uri *url.URL) (*Connection, error) {
 		// {{if .Config.Debug}}
 		log.Printf("Connecting -> %s", uri.Host)
 		// {{end}}
-		lport, err := strconv.Atoi(uri.Port())
-		if err != nil || lport < 0 || lport > 65535 {
+		lport, err := strconv.ParseUint(uri.Port(), 10, 16)
+		if err != nil || lport > 65535 {
 			// {{if .Config.Debug}}
 			log.Printf("Error parsing mtls listen port %s (default to 8888)", err)
 			// {{end}}


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/40](https://github.com/offsoc/sliver/security/code-scanning/40)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
