### PR TITLE
Fix code scanning alert #36: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/procdump/dump_linux.go
+++ b/implant/sliver/procdump/dump_linux.go
@@ -115,11 +115,19 @@ func parseMap(mapLine string) *MemoryRegion {
 			// Something is wrong with this region, discard this record
 			return nil
 		}
+		if regionStart > math.MaxInt64 {
+			// Region start is out of bounds for int64
+			return nil
+		}
 		memRegion.start = regionStart
 
 		regionEnd, err := strconv.ParseUint(regionInformation[2], 16, 64)
 		if err != nil {
 			// Something is wrong with this region, discard this record
+			return nil
+		}
+		if regionEnd > math.MaxInt64 {
+			// Region end is out of bounds for int64
 			return nil
 		}
 		


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/36](https://github.com/offsoc/sliver/security/code-scanning/36)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
