### PR TITLE
Fix code scanning alert #37: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/rportfwd/portfwd.go
+++ b/implant/sliver/rportfwd/portfwd.go
@@ -202,7 +202,7 @@ func (p *ChannelProxy) HostPort() (string, uint32) {
 		// {{end}}
 		return "", defaultPort
 	}
-	portNumber, err := strconv.Atoi(rawPort)
+	portNumber, err := strconv.ParseUint(rawPort, 10, 32)
 	if err != nil {
 		// {{if .Config.Debug}}
 		log.Printf("Failed to parse number from %s", rawPort)


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/37](https://github.com/offsoc/sliver/security/code-scanning/37)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
