### PR TITLE
Fix code scanning alert #38: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -187,7 +187,7 @@ func mtlsBeacon(uri *url.URL) *Beacon {
 	// {{end}}
 	var err error
 	lport, err := strconv.Atoi(uri.Port())
-	if err != nil {
+	if err != nil || lport < 0 || lport > 65535 {
 		lport = 8888
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/38](https://github.com/offsoc/sliver/security/code-scanning/38)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
