### PR TITLE
Fix code scanning alert no. 44: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/util/encoders/english.go
+++ b/util/encoders/english.go
@@ -19,7 +19,8 @@ package encoders
 */
 
 import (
-	insecureRand "math/rand"
+	"crypto/rand"
+	"math/big"
 	"strings"
 )
 
@@ -36,8 +37,11 @@ func (e English) Encode(data []byte) ([]byte, error) {
 	words := []string{}
 	for _, b := range data {
 		possibleWords := dictionary[int(b)]
-		index := insecureRand.Intn(len(possibleWords))
-		words = append(words, possibleWords[index])
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(possibleWords))))
+		if err != nil {
+			return nil, err
+		}
+		words = append(words, possibleWords[idx.Int64()])
 	}
 	return []byte(strings.Join(words, " ")), nil
 }


### PR DESCRIPTION
Fixes [https://github.com/offsoc/sliver/security/code-scanning/44](https://github.com/offsoc/sliver/security/code-scanning/44)

To fix the problem, we need to replace the use of `math/rand` with `crypto/rand` to ensure that the random numbers generated are cryptographically secure. This involves:

1. Updating the `Encode` function in `util/encoders/english.go` to use `crypto/rand` instead of `math/rand`.
2. Ensuring that the random number generation in the `Encode` function is properly handled to avoid errors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
