### PR TITLE
Potential fix for code scanning alert no. 3: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/implant/sliver/encoders/english.go
+++ b/implant/sliver/encoders/english.go
@@ -19,7 +19,8 @@ package encoders
 */
 
 import (
-	insecureRand "math/rand"
+	"crypto/rand"
+	"math/big"
 	"strings"
 )
 
@@ -42,8 +43,11 @@ func (e EnglishEncoder) Encode(data []byte) ([]byte, error) {
 	words := []string{}
 	for _, b := range data {
 		possibleWords := dictionary[int(b)]
-		index := insecureRand.Intn(len(possibleWords))
-		words = append(words, possibleWords[index])
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(possibleWords))))
+		if err != nil {
+			return nil, err
+		}
+		words = append(words, possibleWords[idx.Int64()])
 	}
 	return []byte(strings.Join(words, " ")), nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/3](https://github.com/offsoc/sliver/security/code-scanning/3)

To fix the problem, we need to replace the use of `math/rand` with `crypto/rand` to ensure that the random numbers generated are cryptographically secure. This involves updating the code in `implant/sliver/encoders/english.go` to use `crypto/rand` for generating random indices.

- Replace the import of `math/rand` with `crypto/rand` and `math/big`.
- Update the `Encode` function to use `crypto/rand` for generating random indices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
