### PR TITLE
Potential fix for code scanning alert no. 1: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/implant/sliver/encoders/english.go
+++ b/implant/sliver/encoders/english.go
@@ -19,7 +19,8 @@ package encoders
 */
 
 import (
-	insecureRand "math/rand"
+	"crypto/rand"
+	"math/big"
 	"strings"
 )
 
@@ -42,7 +43,12 @@ func (e EnglishEncoder) Encode(data []byte) ([]byte, error) {
 	words := []string{}
 	for _, b := range data {
 		possibleWords := dictionary[int(b)]
-		index := insecureRand.Intn(len(possibleWords))
+		max := big.NewInt(int64(len(possibleWords)))
+		randIdx, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return nil, err
+		}
+		index := int(randIdx.Int64())
 		words = append(words, possibleWords[index])
 	}
 	return []byte(strings.Join(words, " ")), nil


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/1](https://github.com/offsoc/sliver/security/code-scanning/1)

To fix the problem, replace the use of `math/rand` (`insecureRand.Intn`) in `implant/sliver/encoders/english.go` with a cryptographically secure random number generator. In Go, this means using `crypto/rand` to generate a random index for selecting words. Specifically, in the `Encode` method, replace the line that selects a random index with one that uses `crypto/rand.Int` to securely select an index. This change should be limited to the `implant/sliver/encoders/english.go` file, and will require importing the `crypto/rand` and `math/big` packages. No changes are needed in the other files, as the root cause is the insecure randomness in the encoder.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
