### PR TITLE
Potential fix for code scanning alert no. 41: Insecure TLS configuration

### DIFF
--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -262,7 +262,6 @@ func getHTTPSConfig(req *clientpb.HTTPListenerReq) *tls.Config {
 	// compatibility we need to make sure we always choose at least one modern RSA
 	// option.
 	modernCiphers := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,       //uint16 = 0xc027 16
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,       //uint16 = 0xc02f 17
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,       //uint16 = 0xc030 19
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, //uint16 = 0xcca8 21


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/41](https://github.com/offsoc/sliver/security/code-scanning/41)

To fix the problem, we should remove the insecure cipher suite `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256` from the `modernCiphers` slice in the `getHTTPSConfig` function. This will ensure that only secure cipher suites (GCM and ChaCha20-Poly1305) are considered "modern" and appended to the TLS configuration. The change should be made in the definition of the `modernCiphers` slice (lines 264–269), specifically by deleting the line that adds the CBC-mode cipher. No additional imports or method changes are required; simply remove the insecure cipher from the list.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
