### PR TITLE
Potential fix for code scanning alert no. 40: Insecure TLS configuration

### DIFF
--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -247,8 +247,9 @@ func getHTTPSConfig(req *clientpb.HTTPListenerReq) *tls.Config {
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,       //uint16 = 0xc02c
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,   //uint16 = 0xcca8
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, //uint16 = 0xcca9
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,         //uint16 = 0xc027
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,       //uint16 = 0xc023
+		// Removed CBC-mode cipher suites for security
+		// tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,         //uint16 = 0xc027
+		// tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,       //uint16 = 0xc023
 	}
 	// CipherSuites ignores the order of the ciphers, this random shuffle
 	// is truncated resulting in a random selection from all ciphers


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/40](https://github.com/offsoc/sliver/security/code-scanning/40)

To fix the problem, we should remove the insecure CBC-mode cipher suites from the `allCipherSuites` list. Specifically, remove `tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256` and `tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`. This ensures that only AEAD ciphers (GCM and ChaCha20-Poly1305) are used, which are recommended by current security standards. The rest of the code (random shuffling, selection, and ensuring at least one modern cipher) can remain unchanged. Only the definition of `allCipherSuites` (lines 243–252) needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
