### PR TITLE
Potential fix for code scanning alert no. 36: Size computation for allocation may overflow

### DIFF
--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -56,8 +56,8 @@ func PreludeEncrypt(data []byte, key []byte, iv []byte) []byte {
 	}
 	block, _ := aes.NewCipher(key)
 
-	// Check for integer overflow
-	if len(plainText) > 0 && aes.BlockSize > (1<<31-1)-len(plainText) {
+	// Check for integer overflow in buffer allocation
+	if len(plainText) > 0 && (aes.BlockSize > math.MaxInt-len(plainText)) {
 		return make([]byte, 0)
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/36](https://github.com/offsoc/sliver/security/code-scanning/36)

To fix the problem, we need to ensure that the buffer allocation in `PreludeEncrypt` does not overflow the integer type used by `make`. The best way is to check that the sum `aes.BlockSize + len(plainText)` does not exceed `math.MaxInt` (the maximum value for an `int` on the platform). This should be done immediately before the allocation. If the sum would overflow, the function should return an empty buffer or an error. The fix should be applied in `util/cryptography.go` within the `PreludeEncrypt` function, specifically before the line that allocates the buffer. We should also remove or update the existing overflow check to use this more robust approach. No new imports are needed, as `math` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
