### PR TITLE
Potential fix for code scanning alert no. 27: Incorrect conversion between integer types

### DIFF
--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
+	"math"
 	"github.com/bishopfox/sliver/client/version"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
@@ -90,6 +90,13 @@ func (rpc *Server) GetVersion(ctx context.Context, _ *commonpb.Empty) (*clientpb
 	// Ensure we have at least 3 version components
 	if len(semVer) < 3 {
 		return nil, fmt.Errorf("invalid semantic version: expected at least 3 components, got %d", len(semVer))
+	}
+
+	// Bounds check for int32
+	for i, v := range semVer[:3] {
+		if v < math.MinInt32 || v > math.MaxInt32 {
+			return nil, fmt.Errorf("semantic version component %d out of int32 bounds: %d", i, v)
+		}
 	}
 
 	return &clientpb.Version{


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/27](https://github.com/offsoc/sliver/security/code-scanning/27)

To fix the problem, we need to ensure that the values parsed from the `Version` string and stored in `semVer` are within the valid range for `int32` before converting them. This can be done by adding explicit bounds checks in the `GetVersion` method in `server/rpc/rpc.go` before assigning `semVer[0]`, `semVer[1]`, and `semVer[2]` to the `Major`, `Minor`, and `Patch` fields, respectively. If any value is out of bounds, we should return an error or use a default value. We will need to import the `math` package to access `math.MaxInt32` and `math.MinInt32`. The changes are limited to the `GetVersion` function in `server/rpc/rpc.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
