### PR TITLE
Potential fix for code scanning alert no. 1: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/util/encoders/english.go
+++ b/util/encoders/english.go
@@ -19,7 +19,8 @@ package encoders
 */
 
 import (
-	insecureRand "math/rand"
+	"crypto/rand"
+	"math/big"
 	"strings"
 )
 
@@ -36,7 +37,12 @@ func (e English) Encode(data []byte) ([]byte, error) {
 	words := []string{}
 	for _, b := range data {
 		possibleWords := dictionary[int(b)]
-		index := insecureRand.Intn(len(possibleWords))
+		bigLen := big.NewInt(int64(len(possibleWords)))
+		idxBig, err := rand.Int(rand.Reader, bigLen)
+		if err != nil {
+			return nil, err
+		}
+		index := int(idxBig.Int64())
 		words = append(words, possibleWords[index])
 	}
 	return []byte(strings.Join(words, " ")), nil


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/1](https://github.com/offsoc/sliver/security/code-scanning/1)

To fix the problem, replace the use of `math/rand` in the English encoder with a cryptographically secure random number generator. Specifically, in `util/encoders/english.go`, change the line that selects a random index from the list of possible words for a byte value to use `crypto/rand.Int` instead of `math/rand.Intn`. This requires importing `crypto/rand` and `math/big`, and updating the code to handle the error returned by `rand.Int`. The rest of the functionality should remain unchanged, and the fix should be limited to the `Encode` method of the `English` encoder.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
