### PR TITLE
Potential fix for code scanning alert no. 9: Incorrect conversion between integer types

### DIFF
--- a/client/command/wireguard/wg-socks-stop.go
+++ b/client/command/wireguard/wg-socks-stop.go
@@ -21,6 +21,7 @@ package wireguard
 import (
 	"context"
 	"strconv"
+	"math"
 
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -41,6 +42,10 @@ func WGSocksStopCmd(cmd *cobra.Command, con *console.SliverClient, args []string
 	socksID, err := strconv.Atoi(args[0])
 	if err != nil {
 		con.PrintErrorf("Error converting Socks ID (%s) to int: %s", args[0], err.Error())
+		return
+	}
+	if socksID < math.MinInt32 || socksID > math.MaxInt32 {
+		con.PrintErrorf("Socks ID (%d) is out of int32 range", socksID)
 		return
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/9](https://github.com/offsoc/sliver/security/code-scanning/9)

To fix the problem, we should ensure that the value parsed from `args[0]` is within the valid range for an `int32` before performing the conversion. This can be done by checking that the parsed value is greater than or equal to `math.MinInt32` and less than or equal to `math.MaxInt32`. If the value is out of bounds, we should print an error and return early, preventing the unsafe conversion. This change should be made in the `WGSocksStopCmd` function in `client/command/wireguard/wg-socks-stop.go`. We will also need to import the `math` package to access these constants.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
