### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/client/console/console.go
+++ b/client/console/console.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log"
 	insecureRand "math/rand"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -439,8 +440,16 @@ func (con *SliverClient) PrintLogo() {
 		fmt.Printf(Info+"Client %s\r\n", version.FullVersion())
 	}
 	fmt.Println(Info + "Welcome to the sliver shell, please type 'help' for options\r")
-	if serverVer.Major != int32(version.SemanticVersion()[0]) {
-		fmt.Printf(Warn + "Warning: Client and server may be running incompatible versions.\r\n")
+	semVer := version.SemanticVersion()
+	if len(semVer) > 0 {
+		major := semVer[0]
+		if major >= math.MinInt32 && major <= math.MaxInt32 {
+			if serverVer.Major != int32(major) {
+				fmt.Printf(Warn + "Warning: Client and server may be running incompatible versions.\r\n")
+			}
+		} else {
+			fmt.Printf(Warn + "Warning: Client version major number out of int32 bounds, skipping compatibility check.\r\n")
+		}
 	}
 	con.CheckLastUpdate()
 }


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/10](https://github.com/offsoc/sliver/security/code-scanning/10)

To fix the problem, we need to ensure that the conversion from `int` (result of `strconv.Atoi`) to `int32` is safe and does not result in unexpected values if the parsed integer is outside the valid range for `int32`. The best way to do this is to add an explicit bounds check before performing the conversion, using the constants from the `math` package (`math.MaxInt32` and `math.MinInt32`). If the value is out of bounds, we should handle it gracefully (e.g., by warning, defaulting, or skipping the check).

Specifically, in `client/console/console.go`, in the `PrintLogo` function, on line 442:
```go
if serverVer.Major != int32(version.SemanticVersion()[0]) {
```
We should first check that `version.SemanticVersion()[0]` is within the valid range for `int32` before converting. If it is not, we should either skip the check or use a default value.

This requires importing the `math` package in `client/console/console.go` if it is not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
