### PR TITLE
Potential fix for code scanning alert no. 17: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/procdump/dump_linux.go
+++ b/implant/sliver/procdump/dump_linux.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"math"
 )
 
 /*
@@ -345,6 +346,11 @@ func dumpProcess(pid int32) (ProcessDump, error) {
 				a slice to cut from the buffer
 			*/
 			numberOfBytes := int(region.end - region.start)
+			// Bounds check: ensure region.start fits in int64
+			if region.start > uint64(math.MaxInt64) {
+				// Skip this region or handle error
+				continue
+			}
 			bytesRead, err := processMemory.ReadAt(res.data[currentDumpOffset:currentDumpOffset + numberOfBytes], int64(region.start))
 			if err != nil && err != io.EOF {
 				return res, fmt.Errorf("{{if .Config.Debug}}Error reading process memory{{end}}")


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/17](https://github.com/offsoc/sliver/security/code-scanning/17)

To fix the problem, we need to ensure that the value parsed as a `uint64` (from `strconv.ParseUint`) is within the valid range for an `int64` before converting it. Specifically, before using `int64(region.start)` in line 348, we should check that `region.start` is less than or equal to `math.MaxInt64`. If it is not, we should skip the region or handle the error appropriately. The best way to do this is to add a bounds check in the loop at line 342, before performing the conversion and memory read. We will need to import the `math` package if it is not already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
