### PR TITLE
Potential fix for code scanning alert no. 21: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -239,6 +239,8 @@ func wgBeacon(uri *url.URL) *Beacon {
 	lport, err := strconv.Atoi(uri.Port())
 	if err != nil {
 		lport = 53
+	} else if lport < 0 || lport > int(math.MaxUint16) {
+		lport = 53
 	}
 
 	var conn net.Conn


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/21](https://github.com/offsoc/sliver/security/code-scanning/21)

To fix the problem, we need to ensure that the port value parsed from the URL is within the valid range for a `uint16` (0–65535) before converting it. The best way is to check that `lport` is greater than or equal to 0 and less than or equal to 65535 after parsing. If it is not, we should set it to a safe default (e.g., 53). This check should be added immediately after parsing the port value on line 239. No new methods are needed, but we should use the `math` package's `MaxUint16` constant for clarity and maintainability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
