### PR TITLE
Potential fix for code scanning alert no. 23: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -26,6 +26,7 @@ import (
 
 	// {{if or .Config.IncludeMTLS .Config.IncludeWG}}
 	"strconv"
+	"math"
 	// {{end}}
 
 	// {{if .Config.Debug}}
@@ -337,6 +338,13 @@ func wgConnect(uri *url.URL) (*Connection, error) {
 		if err != nil {
 			// {{if .Config.Debug}}
 			log.Printf("Error parsing wg listen port %s (default to 53)", err)
+			// {{end}}
+			lport = 53
+		}
+		// Check that lport is within valid port range
+		if lport < 0 || lport > int(math.MaxUint16) {
+			// {{if .Config.Debug}}
+			log.Printf("Port out of range (%d), defaulting to 53", lport)
 			// {{end}}
 			lport = 53
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/23](https://github.com/offsoc/sliver/security/code-scanning/23)

To fix the problem, we need to ensure that the parsed port value is within the valid range for a TCP/UDP port (0–65535) before converting it to `uint16`. The best way is to add an explicit bounds check after parsing the port. If the value is out of range, we should default to a safe port (e.g., 53) or return an error. The change should be made in the region after line 342, where `lport` is set, and before it is used in the conversion on line 354. No new methods are needed, but we should use the constant `math.MaxUint16` for clarity, so we need to ensure the `math` package is imported (it is not currently imported in the shown snippet).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
