### PR TITLE
Potential fix for code scanning alert no. 36: Size computation for allocation may overflow

### DIFF
--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -57,7 +57,7 @@ func PreludeEncrypt(data []byte, key []byte, iv []byte) []byte {
 	block, _ := aes.NewCipher(key)
 
 	// Check for integer overflow in buffer allocation
-	if len(plainText) > 0 && (aes.BlockSize > math.MaxInt-len(plainText)) {
+	if len(plainText) > math.MaxInt-aes.BlockSize {
 		return make([]byte, 0)
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/36](https://github.com/offsoc/sliver/security/code-scanning/36)

To fix the problem, we need to ensure that the calculation `aes.BlockSize + len(plainText)` cannot overflow the maximum value of an `int`. The best way to do this is to check that `len(plainText)` is not so large that adding `aes.BlockSize` would exceed `math.MaxInt`. The current check is incorrect (`aes.BlockSize > math.MaxInt-len(plainText)`), and should be replaced with `len(plainText) > math.MaxInt - aes.BlockSize`. Additionally, since the `pad` function already limits the size of `plainText` to 64 MiB plus the block size, this check is mostly defensive, but it is good practice to keep it for clarity and future safety. The change should be made in `util/cryptography.go` in the `PreludeEncrypt` function, replacing the incorrect overflow check with the correct one.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
