### PR TITLE
Potential fix for code scanning alert no. 16: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/procdump/dump_linux.go
+++ b/implant/sliver/procdump/dump_linux.go
@@ -116,6 +116,10 @@ func parseMap(mapLine string) *MemoryRegion {
 			// Something is wrong with this region, discard this record
 			return nil
 		}
+		if regionStart > uint64(math.MaxUintptr) {
+			// Address does not fit in uintptr, discard this region
+			return nil
+		}
 		memRegion.start = regionStart
 
 		regionEnd, err := strconv.ParseUint(regionInformation[2], 16, 64)
@@ -123,7 +127,10 @@ func parseMap(mapLine string) *MemoryRegion {
 			// Something is wrong with this region, discard this record
 			return nil
 		}
-		
+		if regionEnd > uint64(math.MaxUintptr) {
+			// Address does not fit in uintptr, discard this region
+			return nil
+		}
 		memRegion.end = regionEnd
 
 		if regionInformation[4] == "00:00" {


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/16](https://github.com/offsoc/sliver/security/code-scanning/16)

To fix the problem, we need to ensure that the value parsed from `/proc/<pid>/maps` (i.e., `region.start` and `region.end`) does not exceed the maximum value representable by `uintptr` on the current platform before converting it. This can be done by checking that the parsed value is less than or equal to `math.MaxUintptr` (from the `math` package) before assigning it to `memRegion.start` and `memRegion.end` in `parseMap`. If the value exceeds this limit, the region should be discarded (return `nil`). This ensures that later conversions to `uintptr` are always safe and do not result in truncation.

The required changes are:
- In `parseMap`, after parsing `regionStart` and `regionEnd`, check that they are less than or equal to `math.MaxUintptr`. If not, return `nil`.
- No new imports are needed, as `math` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
