### PR TITLE
Potential fix for code scanning alert no. 22: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -240,6 +240,13 @@ func mtlsConnect(uri *url.URL) (*Connection, error) {
 			// {{end}}
 			lport = 8888
 		}
+		// Ensure lport is within the valid range for uint16 (0–65535)
+		if lport < 0 || lport > math.MaxUint16 {
+			// {{if .Config.Debug}}
+			log.Printf("mtls listen port %d out of range (default to 8888)", lport)
+			// {{end}}
+			lport = 8888
+		}
 		conn, err = mtls.MtlsConnect(uri.Hostname(), uint16(lport))
 		if err != nil {
 			return err


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/22](https://github.com/offsoc/sliver/security/code-scanning/22)

To fix this issue, we should ensure that the parsed port number is within the valid range for a TCP/UDP port (0–65535) before casting it to `uint16`. If the value is outside this range, we should default to a safe value (e.g., 8888) or handle the error appropriately. The best way to do this is to add a bounds check after parsing the port number and before casting it to `uint16`. This change should be made in the `mtlsConnect` function, specifically after line 236 and before line 243. No new imports are needed, as `math` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
