### PR TITLE
Potential fix for code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/handlers/handlers_linux.go
+++ b/implant/sliver/handlers/handlers_linux.go
@@ -439,8 +439,8 @@ func chownHandler(data []byte, resp RPCResponse) {
 		goto finished
 	}
 	// Bounds check: ensure uid fits in int32
-	if uid > uint64(math.MaxInt32) {
-		chown.Response.Err = fmt.Sprintf("UID value %d exceeds maximum allowed (%d)", uid, math.MaxInt32)
+	if uid > uint64(math.MaxInt) {
+		chown.Response.Err = fmt.Sprintf("UID value %d exceeds maximum allowed (%d)", uid, math.MaxInt)
 		goto finished
 	}
 
@@ -457,8 +457,8 @@ func chownHandler(data []byte, resp RPCResponse) {
 		goto finished
 	}
 	// Bounds check: ensure gid fits in int32
-	if gid > uint64(math.MaxInt32) {
-		chown.Response.Err = fmt.Sprintf("GID value %d exceeds maximum allowed (%d)", gid, math.MaxInt32)
+	if gid > uint64(math.MaxInt) {
+		chown.Response.Err = fmt.Sprintf("GID value %d exceeds maximum allowed (%d)", gid, math.MaxInt)
 		goto finished
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/12](https://github.com/offsoc/sliver/security/code-scanning/12)

To fix the problem, we need to ensure that the value being converted to `int` is within the valid range for the `int` type on the current platform. The best way to do this is to check that `uid` and `gid` are both less than or equal to `math.MaxInt` (the maximum value for `int` on the current platform) before converting them. This ensures that the conversion to `int` will not overflow, regardless of whether `int` is 32 or 64 bits. The check against `math.MaxInt32` should be replaced with a check against `math.MaxInt`. The same applies to the GID check.

**Files/regions/lines to change:**  
- In `implant/sliver/handlers/handlers_linux.go`, lines 442 and 460: change the bounds check from `math.MaxInt32` to `math.MaxInt`.

**What is needed:**  
- No new imports are needed, as `math` is already imported.
- Only the bounds check constants need to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
