### PR TITLE
Potential fix for code scanning alert no. 16: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/procdump/dump_linux.go
+++ b/implant/sliver/procdump/dump_linux.go
@@ -318,6 +318,11 @@ func dumpProcess(pid int32) (ProcessDump, error) {
 		// Read the memory, region by region
 		for _, region := range(processRegions) {
 			numberOfBytes := int(region.end - region.start)
+			// Check that region.start fits in uintptr before conversion
+			if region.start > uint64(math.MaxUintptr) {
+				// Skip this region, as it cannot be represented as a pointer
+				continue
+			}
 			bytesRead, err := syscall.PtracePeekData(int(pid), uintptr(region.start), res.data[currentDumpOffset:currentDumpOffset + numberOfBytes])
 			if err != nil {
 				return res, fmt.Errorf("{{if .Config.Debug}}Error reading process memory{{end}}")


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/16](https://github.com/offsoc/sliver/security/code-scanning/16)

To fix the problem, ensure that before converting `region.start` (parsed as a `uint64`) to `uintptr`, you check that its value does not exceed `math.MaxUintptr`. This check should be performed immediately before the conversion in the code that calls `syscall.PtracePeekData(int(pid), uintptr(region.start), ...)` (line 321). If the value is out of bounds, skip the region or handle the error appropriately. This ensures that no invalid or truncated pointer values are passed to system calls, preventing undefined behavior.

Specifically, in `dump_linux.go`, in the loop at line 319, add a check before line 321 to ensure `region.start <= uint64(math.MaxUintptr)`. If not, skip the region or return an error. No new imports are needed, as `math` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
