### PR TITLE
Potential fix for code scanning alert no. 18: Incorrect conversion between integer types

### DIFF
--- a/implant/sliver/netstack/tun.go
+++ b/implant/sliver/netstack/tun.go
@@ -968,7 +968,7 @@ func (tnet *Net) DialContext(ctx context.Context, network, address string) (net.
 		acceptV6 = !acceptV4
 	}
 	var host string
-	var port int
+	var port uint16
 	if matches[1] == "ping" {
 		host = address
 	} else {
@@ -978,10 +978,12 @@ func (tnet *Net) DialContext(ctx context.Context, network, address string) (net.
 		if err != nil {
 			return nil, &net.OpError{Op: "dial", Err: err}
 		}
-		port, err = strconv.Atoi(sport)
-		if err != nil || port < 0 || port > 65535 {
+		var port64 uint64
+		port64, err = strconv.ParseUint(sport, 10, 16)
+		if err != nil {
 			return nil, &net.OpError{Op: "dial", Err: errNumericPort}
 		}
+		port = uint16(port64)
 	}
 	allAddr, err := tnet.LookupContextHost(ctx, host)
 	if err != nil {
@@ -991,7 +993,7 @@ func (tnet *Net) DialContext(ctx context.Context, network, address string) (net.
 	for _, addr := range allAddr {
 		ip, err := netip.ParseAddr(addr)
 		if err == nil && ((ip.Is4() && acceptV4) || (ip.Is6() && acceptV6)) {
-			addrs = append(addrs, netip.AddrPortFrom(ip, uint16(port)))
+			addrs = append(addrs, netip.AddrPortFrom(ip, port))
 		}
 	}
 	if len(addrs) == 0 && len(allAddr) != 0 {


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/sliver/security/code-scanning/18](https://github.com/offsoc/sliver/security/code-scanning/18)

To fix the problem, replace the use of `strconv.Atoi` for parsing the port number with `strconv.ParseUint`, specifying a bit size of 16. This will ensure that only valid `uint16` values are accepted, and any out-of-range values will result in a parsing error. Update the code in `implant/sliver/netstack/tun.go` around lines 981-983 to use `strconv.ParseUint`, and update the type of `port` to `uint16`. Remove the manual bounds check, as `ParseUint` will handle it. Ensure that the rest of the code that uses `port` is compatible with the new type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
